### PR TITLE
Fix newline parsing issues for master routing

### DIFF
--- a/src/MyPDOMS.php
+++ b/src/MyPDOMS.php
@@ -190,7 +190,7 @@ class MyPDOMS extends PDO {
 		$query = str_replace("\n", "", $query);
 		$tokens = explode(' ', $query);
 
-		$command = $tokens[0];
+		$command = trim($tokens[0]);
 		if (in_array($command, static::MASTER_COMMANDS)) {
 			$this->last = $this->master;
 			$this->lastUsedHost = 'master';


### PR DESCRIPTION
Given the following query:

```
php >         $sql = "
php "             UPDATE
php "                 a
php "             SET
php "                 a.read = 1
php "             WHERE
php "                 user_id = :user_id
php "             AND
php "                 a.read = 0
php "             ;
php "         ";
```

`$command` parses into:

```
php > var_dump($command);
php shell code:1:
string(7) "UPDATE
"
```

Which is not a match in the master commands due to the newline.  Trimming this result fixes the behavior.